### PR TITLE
Remove archive and clean up UI/codebase

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,6 +38,7 @@ window.addEventListener('load', () => {
      const errorLogLabel = qs('#errorLogLabel')
      const resultsLabel = qs('#resultsLabel')
      
+     const bookUrlMapping = new Map() // Map<url, repoOrSlug>
      let isStopping = false
      let isSkipping = false
      bookCountEl.setAttribute('href', ablUrl)
@@ -51,10 +52,11 @@ window.addEventListener('load', () => {
                el = document.createElement(tagName)
           else
                el = tagName
-          for (const [key, value] in Object.entries(attrs))
+          for (const [key, value] of Object.entries(attrs))
                el.setAttribute(key, value)
-          for (const [key, value] in Object.entries(handlers))
+          for (const [key, value] of Object.entries(handlers))
                el.addEventListener(key, value)
+          el.innerHTML = '' // clear the children
           for (const child of children)
                el.append(child)
           return el
@@ -65,11 +67,11 @@ window.addEventListener('load', () => {
      }
      
      async function fetchWithBackoff(url, useJson) {
-          for (var _ of times(3)) {
+          for (var _ of times(2)) {
                try {
                     return await fetchWithError(url, useJson)
                } catch (err) {
-                    printErrorToUser(err, url)
+                    error(err, url)
                     console.error(`${err}: ${url}`)
                }
                await sleep(300)
@@ -77,7 +79,7 @@ window.addEventListener('load', () => {
           return null
      }
      
-     function printErrorToUser(err, url) {
+     function error(err, url) {
           errorLogLabel.classList = ''
           let li = document.createElement('li')
           let time = new Date().toLocaleTimeString()
@@ -107,7 +109,7 @@ window.addEventListener('load', () => {
      
      let isValid = false
      
-     function getSelectedBooks() {
+     function getSelectedBookUrls() {
           return Array.from(booksEl.querySelectorAll("option:checked"), e => e.value)
      }
      
@@ -115,7 +117,7 @@ window.addEventListener('load', () => {
           if (sourceFormat.value !== 'xhtml' && sourceFormat.value !== 'cnxml') {
                return 'Choose a format to search: XHTML or CNXML'
           }
-          if (getSelectedBooks().length === 0) {
+          if (getSelectedBookUrls().length === 0) {
                return 'Select at least one book'
           }
           const selector = selectorEl.value
@@ -162,6 +164,65 @@ window.addEventListener('load', () => {
           e.preventDefault();
           isStopping = true
      })
+     sourceFormat.forEach(el => {
+          el.addEventListener('change', e => {
+               if (el.checked) populateBookList()
+          })
+     })
+     const relativeHref = (baseFile, href) => {
+          return new URL(href, baseFile).toString()
+     }
+
+     const getPageUrls = async (format, bookUrl) => {
+          if (format === 'xhtml') {
+               const bookJson = await fetchWithBackoff(bookUrl, true)
+               const pageUuids = []
+               recLeafPages(pageUuids, bookJson.tree)
+               const pageUrls = pageUuids.map(pageUuid => {
+                    const parseUrl = bookUrl.replace('.json', `:${pageUuid.replace('@', '')}.json`)
+                    const viewUrl = parseUrl.replace('.json', '.xhtml')
+                    return {parseUrl, viewUrl}
+               })
+               return pageUrls
+          } else if (format === 'cnxml') {
+               const metaInfBooksXml = await fetchWithBackoff(bookUrl, false)
+               sandboxEl.innerHTML = metaInfBooksXml.replace(/ src=/g, ' data-src=')
+               //List of collection.xml files
+               const collectionXMLLinks = Array.from(sandboxEl.querySelectorAll("book[href]"), e => e.attributes.getNamedItem('href').value)
+               const bookUrls = collectionXMLLinks.map(href => relativeHref(bookUrl, href))
+               const pageUrls = []
+               for (const collectionXMLUrl of bookUrls) {
+                    const collectionXML = await fetchWithBackoff(collectionXMLUrl, false)
+                    sandboxEl.innerHTML = collectionXML
+                    sandboxEl.querySelectorAll('[document]').forEach(module => {
+                         const parseUrl = new URL(relativeHref(collectionXMLUrl, `../modules/${module.getAttribute('document')}/index.cnxml`))
+                         const paths = parseUrl.pathname.split('/')
+                         // paths[0] is always '' because .pathname begins with `/`
+                         const repoName = paths[1]
+                         const restOfPath = paths.slice(2).join('/')
+                         const viewUrl = `${githubServerURL}/${repoName}/tree/main/${restOfPath}`
+                         pageUrls.push({parseUrl: parseUrl.toString(), viewUrl})
+                    })
+               }
+               return pageUrls
+          }
+     }
+     const getPageXML = async (format, pageUrl) => {
+          if (format === 'xhtml') {
+               const page = await fetchWithBackoff(pageUrl, true)
+               if (page)
+                    return {
+                         title: page.slug,
+                         source: page.content
+                    }
+               else
+                    return {}
+          } else if (format === 'cnxml') {
+               return {
+                    source: await fetchWithBackoff(pageUrl, false)
+               }
+          }
+     }
      const startFn = async () => {
           // For each book, fetch the ToC
           // Fetch each Page
@@ -172,7 +233,7 @@ window.addEventListener('load', () => {
           
           const selector = selectorEl.value
           
-          const selectedBooks = getSelectedBooks()
+          const selectedUrls = getSelectedBookUrls()
           
           resultsLabel.classList = ''
           
@@ -188,9 +249,11 @@ window.addEventListener('load', () => {
           skipEl.disabled = false
           
           // these are done in parallel
-          for (const bookUuid of selectedBooks) {
-               //Retrieve the book object from local storage
-               const book = JSON.parse(window.localStorage.getItem(bookUuid))
+          for (const bookUrl of selectedUrls) {
+               if (isStopping) break
+
+               const pageUrls = await getPageUrls(sourceFormat.value, bookUrl) // Array<{parseUrl, viewUrl}>
+
                //Find the book type
                let totalMatches = 0
                isSkipping = false
@@ -209,147 +272,42 @@ window.addEventListener('load', () => {
                
                detailsEl.append(bookResultsEl)
                resultsEl.prepend(t1)
+
                
-               let bookUrl = null
-               let bookJson = null
-               let collectionXMLLinks
-               //Download the book.xml from Github
-               bookXML = await fetchWithBackoff(`${openstaxGithubURL}/${book.repository_name}/META-INF/books.xml`, false)
-               // the bookXml is null when the repository is private, We will skip to the next book in that case
-               if(!bookXML) {
-                    continue;
-               }
-               sandboxEl.innerHTML = bookXML.replace(/ src=/g, ' data-src=')
-               //List of collection.xml files
-               collectionXMLLinks = Array.from(sandboxEl.querySelectorAll("book[href]"), e => e.attributes.getNamedItem('href').value)
-               const pipelines = JSON.parse(window.localStorage.getItem('pipelines'))
-               const commit_shas = []
-               book.versions.forEach(v => commit_shas.push(v.commit_sha.substring(0, 7)))
-               for (let pipeline of pipelines) {
-                    for (let commitSha of commit_shas) {
-                         bookUrl = `${s3RootUrl}/${pipeline}/contents/${bookUuid}@${commitSha}.json`
-                         try {
-                              //Find the right book.json file and exit the loop
-                              bookJson = await fetchWithBackoff(bookUrl, true)
-                              if (bookJson != null && bookJson.title != null) break
-                         } catch (error) {
-                              console.error(error)
-                              continue;
-                         }
+               for (let i = 0; i < pageUrls.length; i++) {
+                    if (isStopping || isSkipping) break
+
+                    const {parseUrl, viewUrl} = pageUrls[i]
+                    const {title, source} = await getPageXML(sourceFormat.value, parseUrl)
+                    if (!source) {
+                         error(`Could not fetch ${parseUrl}`)
+                         detailsEl.append(dom('li', {}, `Error: Could not fetch ${parseUrl}`))
+                         continue
                     }
-                    if (bookJson != null && bookJson.title != null) break
-               }
-               
-               
-               
-               
-               if (bookJson == null) {
-                    printErrorToUser(`Could not find a baked version of ${bookUuid}. Book details: ${JSON.stringify(book)}`, null)
-                    continue
-               }
-               bookTitleEl.textContent = bookJson.title
-               bookUrl = bookUrl.replace('.json', '')
-               if (sourceFormat.value === 'cnxml') {
-                    for (let link of collectionXMLLinks) {
-                         link = link.replace("../", "")
-                         let collectionXML = await fetchWithBackoff(`${openstaxGithubURL}/${book.repository_name}/${link}`, false)
-                         sandboxEl.innerHTML = collectionXML.replace(/ src=/g, 'data-src')
-                         let modules = Array.from(sandboxEl.querySelectorAll("module[document]"), e => e.attributes.getNamedItem('document').value)
-                         for (let module of modules) {
-                              const i = modules.indexOf(module)
-                              let indexCNXMLLink = `${openstaxGithubURL}/${book.repository_name}/modules/${module}/index.cnxml`
-                              let indexCNXML = await fetchWithBackoff(indexCNXMLLink, false)
-                              sandboxEl.innerHTML = indexCNXML
-                              let pageTitle = sandboxEl.querySelector("title").innerHTML
-                              const matches = findMatches(selector, indexCNXML)
-                              totalMatches += matches.length
-                              bookLogEl.textContent = `(${i + 1}/${modules.length}. Found ${totalMatches})`
-                              // Add a list of links to the matched elements
-                              for (const match of matches) {
-                                   detailsEl.classList.add('found-matches')
-                                   
-                                   const nearestId = findNearestId(match)
-                                   const nodeValue = getNodeValue(match)
-                                   
-                                   const li = document.createElement('li')
-                                   //Issue With how to rewrite the redirection URL to the right cnxml file attribute
-                                   const moduleInfo = `<a target="_blank" href="${githubServerURL}/${book.repository_name}/blob/main/modules/${module}/index.cnxml#${nearestId}">${module}</a> `
-                                   try {
-                                        li.innerHTML = `${moduleInfo}${pageTitle} <a target="_blank" href="${githubServerURL}/${book.repository_name}/blob/main/modules/${module}/index.cnxml#${nearestId}">${nodeValue}</a>`
-                                   } catch (e) {
-                                        console.error(e)
-                                        console.log('invalid XML')
-                                        continue
-                                   }
-                                   bookResultsEl.append(li)
-                              }
-                              
-                         }
-                    }
-               } else {
-                    
-                    const pageRefs = []
-                    recLeafPages(pageRefs, bookJson.tree)
-                    
-                    for (const pageRef of pageRefs) {
+
+                    const matches = findMatches(selector, source)
+                    const pageTitleEl = sandboxEl.querySelector("title") // findMatches populates sandboxEl
+                    let pageTitle = title ? title : pageTitleEl ? pageTitleEl.innerHTML : parseUrl
+                    totalMatches += matches.length
+                    bookLogEl.textContent = `${bookUrlMapping.get(bookUrl) || bookUrl} (${i + 1}/${pageUrls.length}. Found ${totalMatches})`
+                    // Add a list of links to the matched elements
+                    for (const match of matches) {
+                         detailsEl.classList.add('found-matches')
+                         
+                         const nearestId = findNearestId(match)
+                         const nodeValue = getNodeValue(match)
+                         
+                         const li = document.createElement('li')
+                         //Issue With how to rewrite the redirection URL to the right cnxml file attribute
                          try {
-                              const i = pageRefs.indexOf(pageRef)
-                              
-                              pageRef.id = pageRef.id.replace("@", '')
-                              const pageUrl = `${bookUrl}:${pageRef.id}`
-                              const pageJson = await fetchWithBackoff(`${pageUrl}.json`, true)
-                              
-                              
-                              let sourceCode
-                              if (bookJson) {
-                                   sourceCode = pageJson.content
-                              } else continue;
-                              
-                              const matches = findMatches(selector, sourceCode)
-                              totalMatches += matches.length
-                              bookLogEl.textContent = `(${i + 1}/${pageRefs.length}. Found ${totalMatches})`
-                              
-                              // Add a list of links to the matched elements
-                              for (const match of matches) {
-                                   detailsEl.classList.add('found-matches')
-                                   
-                                   const nearestId = findNearestId(match)
-                                   const nodeValue = getNodeValue(match)
-                                   
-                                   const li = document.createElement('li')
-                                   const moduleInfo = ''
-                                   
-                                   try {
-                                        li.innerHTML = `${pageJson.title} <a target="_blank" href="${pageUrl}.xhtml#${nearestId}">${nodeValue}</a>`
-                                   } catch (e) {
-                                        console.error(e)
-                                        console.log('invalid XML')
-                                   }
-                                   bookResultsEl.append(li)
-                              }
-                              
-                              
-                              // Break when stop button is pressed
-                              if (isStopping) {
-                                   selectorEl.disabled = false
-                                   startEl.disabled = false
-                                   booksEl.disabled = false
-                                   stopEl.disabled = true
-                                   skipEl.disabled = true
-                                   return
-                              }
-                              if (isSkipping) {
-                                   break
-                              }
-                         } catch (error) {
-                              console.error(error)
+                              li.innerHTML = `${pageTitle} <a target="_blank" href="${viewUrl}#${nearestId}">${nodeValue}</a>`
+                         } catch (e) {
+                              error('Invalid XML', parseUrl)
                               continue
                          }
-                         
+                         bookResultsEl.append(li)
                     }
                }
-               
-               
           }
           
           selectorEl.disabled = false
@@ -378,6 +336,7 @@ window.addEventListener('load', () => {
      function doStart() {
           if (isValid) {
                startFn().then(null, (err) => {
+                    error(err.message)
                     console.error(err.message)
                     alert(`Error: ${err.message}`)
                     selectorEl.disabled = false
@@ -388,63 +347,105 @@ window.addEventListener('load', () => {
           }
      }
      
-     
+     let loadedRepos = null // Array<{repoName, url, error?: string}>
+     let loadedBooks = null // Map<slug, url>
+     let failedBooks = null // Map<slug, {commit_sha, uuid, pipeline, url, error?: string}>
      fetch(ablUrl).then(async res => {
           const approvedBookList = await res.json()
           console.log('Here is the approved book list:', approvedBookList)
           if (approvedBookList.api_version !== TESTED_ABL_VERSION) {
                alert(`Sifter is tested to work with ABL version ${TESTED_ABL_VERSION} but the current api_version is '${approvedBookList.api_version}'. Stuff may not work`)
           }
-          const bookIdAndSlugs = [] // {uuid, slug, collection_id}
-          const pipelines = []
+          const ablRepos = new Set() // Set<string>
+          const ablBookSlugCommitPairs = new Set() // Set<{slug, uuid, commit_sha}>
+          const ablPipelines = new Set() // Set<string>
           
           // collect all the books & remember if they are archive/git
           approvedBookList.approved_books.forEach(bookContainer => {
                if (bookContainer.repository_name) {
+                    ablRepos.add(bookContainer.repository_name)
                     bookContainer.versions.forEach(v => {
-                         if (pipelines.indexOf(v.min_code_version) === -1) pipelines.push(v.min_code_version)
+                         ablPipelines.add(v.min_code_version)
                          v.commit_metadata.books.forEach(book => {
-                              bookIdAndSlugs.push({...bookContainer, ...book})
-                              window.localStorage.setItem(book.uuid, JSON.stringify(bookContainer))
+                              ablBookSlugCommitPairs.add({slug: book.slug, uuid: book.uuid, commit_sha: v.commit_sha})
                          })
                     })
-               } else if (bookContainer.collection_id) {
-                    bookContainer.books.forEach(book => {
-                         bookIdAndSlugs.push({...bookContainer, ...book})
-                         window.localStorage.setItem(book.uuid, JSON.stringify(bookContainer))
-                    })
                } else {
-                    console.error("Unsupported approved_book format")
+                    error("Unsupported approved_book format", ablUrl)
                }
           })
-          // sort by Book slug
-          bookIdAndSlugs.sort((a, b) => {
-               if (a.slug.toLowerCase() < b.slug.toLowerCase()) return -1
-               if (a.slug.toLowerCase() > b.slug.toLowerCase()) return 1
-               return 0
-          })
-          pipelines.sort((a, b) => {
+          const ablPipelinesSorted = Array.from(ablPipelines).sort((a, b) => {
                return a < b ? 1 : (a > b ? -1 : 0)
           })
-          window.localStorage.setItem('pipelines', JSON.stringify(pipelines))
-          bookIdAndSlugs.forEach(({uuid, slug, collection_id}) => {
-               const o = document.createElement('option')
-               o.setAttribute('value', uuid)
-               o.setAttribute('selected', 'selected')
-               o.append(slug)
-               booksEl.append(o)
-          })
+
+          // Load the books to check & see which ones are not even valid (like a missing GH-Pages, or not generated in the most-recent pipeline)
           
-          bookCountEl.textContent = bookIdAndSlugs.length
+          loadedRepos = [] // Array<{repoName, url, error?: string}>
+          for (const repoName of ablRepos) {
+               const url = `${openstaxGithubURL}/${repoName}/META-INF/books.xml`
+               const metaInfBooksXml = await fetchWithBackoff(url, false)
+               if (metaInfBooksXml) {
+                    loadedRepos.push({repoName, url})
+               } else {
+                    loadedRepos.push({repoName, url, error: `Enable GitHub Pages`})
+               }
+          }
+          loadedBooks = new Map() // Map<slug, {url}>
+          failedBooks = new Map() // Map<slug, {url, error: string|null}>
+          for (const pipeline of ablPipelinesSorted) {
+               for (const {slug, uuid, commit_sha} of ablBookSlugCommitPairs) {
+                    if (!loadedBooks.has(slug)) {
+                         const shortSha = commit_sha.substring(0, 7)
+                         const url = `${s3RootUrl}/${pipeline}/contents/${uuid}@${shortSha}.json`
+                         const bookJson = fetchWithBackoff(url, true)
+                         if (bookJson) {
+                              loadedBooks.set(slug, {url})
+                              failedBooks.delete(slug)
+                         } else {
+                              failedBooks.set(slug, {url, error: 'Could not find book in S3'})
+                         }
+                    }
+               }
+          }
+
+          populateBookList()
+          
+          bookCountEl.textContent = ablRepos.size
           validateSelector()
           
      }, err => alert(`Problem getting the approved book list. Maybe you are offline or the URL has moved. '${ablUrl}'`))
      
+     async function populateBookList() {
+          if (sourceFormat.value === 'xhtml') {
+               const loadedAndFailedBooks = [
+                    ...failedBooks,
+                    ...loadedBooks
+               ]
+               dom(booksEl, {}, loadedAndFailedBooks.map(([slug, {url, error}]) => {
+                    bookUrlMapping.set(url, slug)
+                    if (error)
+                         return dom('option', {value: url, disabled: true}, [`${slug} Error: ${error}`])
+                    else
+                         return dom('option', {value: url, selected: true}, [slug])
+               }))
+          } else if (sourceFormat.value === 'cnxml') {
+               dom(booksEl, {}, loadedRepos.map(({repoName, url, error}) => {
+                    bookUrlMapping.set(url, repoName)
+                    if (error)
+                         return dom('option', {value: url, disabled: true}, [`${repoName} Error: ${error}`])
+                    else
+                         return dom('option', {value: url, selected: true}, [repoName])
+               }))
+          } else {
+               error(`Unsupported sourceFormat: ${sourceFormat}`)
+          }
+     }
+
      function recLeafPages(acc, node) {
           if (node.contents) {
                node.contents.forEach((child) => recLeafPages(acc, child))
-          } else {
-               acc.push(node)
+          } else if (node.id.endsWith('@')) { // Autogenerated Pages end with '@{sha}' instead of '@' for some reason
+               acc.push(node.id.replace('@', ''))
           }
      }
      
@@ -466,7 +467,7 @@ window.addEventListener('load', () => {
           if (selector[0] === '/') {
                // Verify that the Xpath selector begins with "/h:" or "//h:" or "//m:"
                // See https://developer.mozilla.org/en-US/docs/Web/XPath/Introduction_to_using_XPath_in_JavaScript#Implementing_a_User_Defined_Namespace_Resolver
-               if (/^\/[h,c,m]:/.test(selector) || /^\/\/[h,c,m]:/.test(selector)) {
+               if (/^\/{1,2}[h,c,m]:/.test(selector) || /^\/\/\*/.test(selector)) {
                     const xpathResult = document.evaluate(selector, sandboxEl, xpathNamespaceResolver, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null)
                     const ret = []
                     for (let i = 0; i < xpathResult.snapshotLength; i++) {

--- a/app.js
+++ b/app.js
@@ -247,6 +247,9 @@ window.addEventListener('load', () => {
           booksEl.disabled = true
           stopEl.disabled = false
           skipEl.disabled = false
+          sourceFormat.forEach(el => {
+               el.disabled = true
+          })
           
           // these are done in parallel
           for (const bookUrl of selectedUrls) {
@@ -315,6 +318,9 @@ window.addEventListener('load', () => {
           booksEl.disabled = false
           stopEl.disabled = true
           skipEl.disabled = true
+          sourceFormat.forEach(el => {
+               el.disabled = false
+          })
           
      }
      
@@ -343,6 +349,9 @@ window.addEventListener('load', () => {
                     startEl.disabled = false
                     stopEl.disabled = true
                     skipEl.disabled = true
+                    sourceFormat.forEach(el => {
+                         el.disabled = false
+                    })
                })
           }
      }
@@ -415,13 +424,16 @@ window.addEventListener('load', () => {
           
      }, err => alert(`Problem getting the approved book list. Maybe you are offline or the URL has moved. '${ablUrl}'`))
      
+     const compareStrings = (a, b) => a < b ? -1 : a > b ? 1 : 0
+     const compareKeys = ([a], [b]) => compareStrings(a, b)
+     const compareRepoNames = ({repoName: a}, {repoName: b}) => compareStrings(a, b)
      async function populateBookList() {
           if (sourceFormat.value === 'xhtml') {
                const loadedAndFailedBooks = [
                     ...failedBooks,
                     ...loadedBooks
                ]
-               dom(booksEl, {}, loadedAndFailedBooks.map(([slug, {url, error}]) => {
+               dom(booksEl, {}, loadedAndFailedBooks.sort(compareKeys).map(([slug, {url, error}]) => {
                     bookUrlMapping.set(url, slug)
                     if (error)
                          return dom('option', {value: url, disabled: true}, [`${slug} Error: ${error}`])
@@ -429,7 +441,7 @@ window.addEventListener('load', () => {
                          return dom('option', {value: url, selected: true}, [slug])
                }))
           } else if (sourceFormat.value === 'cnxml') {
-               dom(booksEl, {}, loadedRepos.map(({repoName, url, error}) => {
+               dom(booksEl, {}, loadedRepos.sort(compareRepoNames).map(({repoName, url, error}) => {
                     bookUrlMapping.set(url, repoName)
                     if (error)
                          return dom('option', {value: url, disabled: true}, [`${repoName} Error: ${error}`])

--- a/index.xhtml
+++ b/index.xhtml
@@ -76,7 +76,9 @@
         </ul>
         <label for="books">Books to search:</label>
         <br/>
-        <select id="books" name="books" multiple="multiple" class="col-sm-8" size="15"></select>
+        <select id="books" name="books" multiple="multiple" class="col-sm-8" size="15">
+            <option disabled="disabled">Loading... hopefully</option>
+        </select>
     </form>
     <h4 class="search-not-started" id="resultsLabel">Results</h4>
     <ul id="results"></ul>

--- a/index.xhtml
+++ b/index.xhtml
@@ -67,36 +67,13 @@
             <button id="stop" disabled="disabled">Stop</button>
             <button id="skip" disabled="disabled">Skip</button>
         </div>
-        <label for="stop-after-one">Stop after one is found (faster):</label>
-        <input id="stop-after-one" type="checkbox"/>
         <br/>
-        <label for="stop-after-n-pages">Stop after the first N pages (faster):</label>
-        <input id="stop-after-n-pages" type="number"/>
-        <br/>
-        <label for="advanced-toggle">Run custom JavaScript for each Book/Page</label>
-        <input id="advanced-toggle" type="checkbox"/>
-        <div id="advanced-area">
-            <br/>
-            <p>The arguments available are:</p>
-            <ul>
-                <li><strong>type</strong>: It is one of 'BOOK:START', 'PAGE', or 'BOOK:END'</li>
-                <li><strong>json</strong></li>
-                <li><strong>bookUuid</strong></li>
-                <li><strong>pageUuid</strong> (if applicable)</li>
-            </ul>
-            <label for="analyze-code">Extra JS to run:</label>
-            <br/>
-            <textarea name="code" id="analyze-code" cols="80" rows="10"></textarea>
-        </div>
         <ul>
             <li><input type="radio" id="use-xhtml" name="sourceFormat" value="xhtml"/><label for="use-xhtml">Search
                 XHTML</label></li>
             <li><input type="radio" id="use-cnxml" name="sourceFormat" value="cnxml"/><label for="use-cnxml">Search
                 CNXML</label></li>
         </ul>
-        <label for="show-log">Show Log:</label>
-        <input id="show-log" type="checkbox"/>
-        <br />
         <label for="books">Books to search:</label>
         <br/>
         <select id="books" name="books" multiple="multiple" class="col-sm-8" size="15"></select>

--- a/index.xhtml
+++ b/index.xhtml
@@ -64,8 +64,6 @@
             <div id="validation-message"></div>
             <input name="q" id="selector" placeholder="CSS or XPath (//h:*) Selector" class="col-sm-6"/>
             <button type="submit" id="start">Start</button>
-            <button id="stop" disabled="disabled">Stop</button>
-            <button id="skip" disabled="disabled">Skip</button>
         </div>
         <br/>
         <ul>
@@ -81,6 +79,10 @@
         </select>
     </form>
     <h4 class="search-not-started" id="resultsLabel">Results</h4>
+    <p>
+        <button id="stop" disabled="disabled">Stop</button>
+        <button id="skip" disabled="disabled">Skip</button>
+    </p>
     <ul id="results"></ul>
     <h4 class="search-not-started" id="errorLogLabel">Error Log</h4>
     <ul id="errors" style="font-size: x-small">


### PR DESCRIPTION
refs openstax/ce#1853

# Description

- removes searching legacy content
- list shows repos or books depending on if CNXML or XHTML is selected
- combines XHTML & CNXML-specific logic into 2 common methods: `getPageUrls(format, url)` and `getPageXML(format, url)`
- repo errors are detected before searching even begins


# Screencast

https://user-images.githubusercontent.com/253202/158766577-db700a98-a739-4153-bf2f-dea1fa4f57ef.mp4

